### PR TITLE
PP-73: restrict typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "2.3.0",
     "ts-loader": "^9.2.3",
     "ts-node": "8.6.2",
-    "typescript": "^4.3.5",
+    "typescript": "4.3.5",
     "webpack": "^5.43.0",
     "webpack-cli": "^4.7.2",
     "webpack-node-externals": "^3.0.0"


### PR DESCRIPTION
This PR restricts the typescript version used in the project to prevent build differences.

For now, we're OK with using the older version to move forward. [PP-75](https://rsklabs.atlassian.net/browse/PP-75) is a follow-up issue to tackle any build differences or errors that might come up.