### PR TITLE
PP-94: Fix truffle typings patch 

### DIFF
--- a/dist/EIP712/ForwardRequest.d.ts
+++ b/dist/EIP712/ForwardRequest.d.ts
@@ -4,7 +4,7 @@ export interface ForwardRequest {
     from: string;
     to: string;
     tokenContract: string;
-    collectorContract?: string;
+    collectorContract: string;
     value: string;
     gas: string;
     nonce: string;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@openeth/truffle-typings": "0.0.6",
     "@openzeppelin/contracts": "~3.2.0",
-    "@rsksmart/rif-relay-contracts": "https://github.com/anarancio/rif-relay-contracts#PP-94/revenue-sharing-model",
+    "@rsksmart/rif-relay-contracts": "https://github.com/antomor/rif-relay-contracts#PP-94/fix-truffle-typings-patch",
     "@truffle/contract": "~4.2.23",
     "@truffle/contract-schema": "3.3.2",
     "@truffle/hdwallet-provider": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@openeth/truffle-typings": "0.0.6",
     "@openzeppelin/contracts": "~3.2.0",
-    "@rsksmart/rif-relay-contracts": "https://github.com/antomor/rif-relay-contracts#PP-94/fix-truffle-typings-patch",
+    "@rsksmart/rif-relay-contracts": "https://github.com/anarancio/rif-relay-contracts#PP-94/revenue-sharing-model",
     "@truffle/contract": "~4.2.23",
     "@truffle/contract-schema": "3.3.2",
     "@truffle/hdwallet-provider": "1.2.4",

--- a/patches/@openeth+truffle-typings+0.0.6.patch
+++ b/patches/@openeth+truffle-typings+0.0.6.patch
@@ -18,7 +18,6 @@ index 5de91fb..86d9264 100644
 +    tokenAmount?: BN | number | string;
 +    tokenContract?: string;
 +    forceGas?: BN | number | string;
-+    collectorContract?: string;
    }
  
    export interface TransactionLog {

--- a/patches/@openeth+truffle-typings+0.0.6.patch
+++ b/patches/@openeth+truffle-typings+0.0.6.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@openeth/truffle-typings/index.d.ts b/node_modules/@openeth/truffle-typings/index.d.ts
-index 5de91fb..86d9264 100644
+index 5de91fb..85cf390 100644
 --- a/node_modules/@openeth/truffle-typings/index.d.ts
 +++ b/node_modules/@openeth/truffle-typings/index.d.ts
-@@ -46,11 +46,14 @@ declare namespace Truffle {
+@@ -46,11 +46,15 @@ declare namespace Truffle {
      gas?: BN | number | string;
      gasPrice?: BN | number | string;
      value?: BN | string;
@@ -18,6 +18,7 @@ index 5de91fb..86d9264 100644
 +    tokenAmount?: BN | number | string;
 +    tokenContract?: string;
 +    forceGas?: BN | number | string;
++    collectorContract?: string;
    }
  
    export interface TransactionLog {

--- a/patches/@openeth+truffle-typings+0.0.6.patch
+++ b/patches/@openeth+truffle-typings+0.0.6.patch
@@ -18,6 +18,7 @@ index 5de91fb..86d9264 100644
 +    tokenAmount?: BN | number | string;
 +    tokenContract?: string;
 +    forceGas?: BN | number | string;
++    collectorContract?: string;
    }
  
    export interface TransactionLog {

--- a/src/EIP712/ForwardRequest.ts
+++ b/src/EIP712/ForwardRequest.ts
@@ -5,7 +5,7 @@ export interface ForwardRequest {
     from: string;
     to: string;
     tokenContract: string;
-    collectorContract?: string;
+    collectorContract: string;
     value: string;
     gas: string;
     nonce: string;


### PR DESCRIPTION
## What

- Fix truffle typings patch
- make the collectorContract field mandatory

## Why

- We may need to specify the `collectorContract` parameter, so we need to fix the type `Truffle.TransactionDetails` automatically generated by truffle.
